### PR TITLE
fix: 타임 테이블 상단 아이템 클릭시 상세보기 창이 해당 아이템 시작 날짜로 보이던 문제 수정

### DIFF
--- a/Haru/Views/TimeTable/TimeTableScheduleTopView.swift
+++ b/Haru/Views/TimeTable/TimeTableScheduleTopView.swift
@@ -67,13 +67,7 @@ struct TimeTableScheduleTopView: View {
                         .position(
                             calcTopItemPosition(weight: schedule.weight, index: index, order: schedule.order)
                         )
-                        .onTapGesture {
-                            calendarViewModel.pivotDate = timeTableViewModel.thisWeek[index]
-                            calendarViewModel.getSelectedScheduleList()
-                            withAnimation {
-                                isPopupVisible = true
-                            }
-                        }
+                        .allowsHitTesting(false)
                     }
                 }
             }


### PR DESCRIPTION
### 개요
- 제목과 동일